### PR TITLE
ci: GitHub issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,0 +1,66 @@
+name: Bug Report
+description: File a bug report, for example a bug in the code or a typo, or a typo in the documentation.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report! Please ensure this issue is not already reported by searching the [issue tracker](https://https://github.com/LeagueOfPoro/CapsuleFarmerEvolved/issues) for a similar issue. Please do not use this template for questions! If you have a question, please ask it our Discord server. If you have a feature request, please use the feature request template.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What the issue is, where it can be found, and what it affects.
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+  - type: textarea
+    id: what-should-happen
+    attributes:
+      label: What should happen?
+      description: What you expected to happen. If you have a suggestion, tell us how you think it should work.
+      placeholder: Tell us what you expect!
+    validations:
+      required: true
+  - type: textarea
+    id: version
+    attributes:
+      label: Capsule Farmer Version
+      description: Please tell us what version of Capsule Farmer you are running.
+      placeholder: v1.1
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      description: What operating system are you running?
+      options:
+        - Windows 10
+        - Windows 11
+        - Other (Non Windows are not natively supported)
+    validations:
+      required: true
+  - type: textarea
+    id: os-version
+    attributes:
+      label: Operating System Version
+      description: What version of the operating system are you running? 
+      placeholder: Windows 10 21H1 Build 19043.1237
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: My issue is not a question
+      description: Please ensure that you are not asking a question. If you have a question, please ask it our Discord server. If you have a feature request, please use the feature request template. By submitting this issue, you agree this issue is not a question or a feature request. Your issue will be closed if it is a question or feature request.
+      options:
+        - label: I acknowledge that this issue is not a question or feature request.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions or Discussions
+    url: https://discord.gg/ebm5MJNvHU/
+    about: "Check out our Discord server for questions or discussions! Locate the #capsule-farmer channel!"

--- a/.github/ISSUE_TEMPLATE/suggestions.yaml
+++ b/.github/ISSUE_TEMPLATE/suggestions.yaml
@@ -1,0 +1,33 @@
+name: Feature Request
+description: Suggest an idea for this project
+title: "[Suggestion]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request! Please ensure this issue is not already reported by searching the [issue tracker](https://https://github.com/LeagueOfPoro/CapsuleFarmerEvolved/issues) for a similar issue. Please do not use this template for questions! If you have a question, please ask it our Discord server. If you have a bug report, please use the bug report template.
+  - type: textarea
+    id: your-idea
+    attributes:
+      label: What is your idea?
+      description: Please be as descriptive as possible. Explain what you want to happen, and why you think it would be a good addition to Capsule Farmer.
+      placeholder: Tell us what you want!
+    validations:
+      required: true
+  - type: textarea
+    id: what-should-happen
+    attributes:
+      label: What should happen?
+      description: What you expected to happen. If you have a suggestion, tell us how you think it should work.
+      placeholder: Tell us what you expect!
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: My request is not a question
+      description: Please ensure that you are not asking a question. If you have a question, please ask it our Discord server. If you have a bug report, please use the issue request template. By submitting this suggestion, you agree this request is not a question or a bug report. Your issue will be closed if it is a question or a bug report.
+      options:
+        - label: I acknowledge that this issue is not a question or a bug request.
+          required: true


### PR DESCRIPTION
This PR aims on adding proper templates for GitHub issues. This will allow easier management between questions & actual bugs/issues. 