### PR TITLE
feat: Discord Webhook Support

### DIFF
--- a/FarmThread.py
+++ b/FarmThread.py
@@ -73,5 +73,26 @@ class FarmThread(Thread):
 
     def __notifyConnectorDrops(self, newDrops: list):
         if newDrops:
-            requests.post(self.config.connectorDrops, json=newDrops)
+            if "https://discord.com/api/webhooks" in self.config.connectorDrops:
+                for x in range(len(newDrops)):
+                    title = newDrops[x]["dropsetTitle"]
+                    thumbnail = newDrops[x]["dropsetImages"]["cardUrl"]
+                    reward = newDrops[x]["inventory"][0]["localizedInventory"]["title"]["en_US"]
+                    rewardImage = newDrops[x]["inventory"][0]["localizedInventory"]["inventory"]["imageUrl"]
 
+                    embed = {
+                        "title": f"{title}",
+                        "description": f"We claimed an **{reward}** from <https://lolesports.com/rewards>",
+                        "image" : {"url": f"{thumbnail}"},
+                        "thumbnail": {"url": f"{rewardImage}"},
+                        "color": 6676471,
+                    }
+
+                    params = {
+                        "username" : "LoL Esports",
+                        "avatar_url": "http://assets.lolesports.com/watch/lolesports-icon-ice.png",
+                        "embeds": [embed]
+                    }
+                    requests.post(self.config.connectorDrops, headers={"Content-type":"application/json"}, json=params)
+            else:
+                requests.post(self.config.connectorDrops, json=newDrops)

--- a/FarmThread.py
+++ b/FarmThread.py
@@ -81,7 +81,7 @@ class FarmThread(Thread):
                     rewardImage = newDrops[x]["inventory"][0]["localizedInventory"]["inventory"]["imageUrl"]
 
                     embed = {
-                        "title": f"{title}",
+                        "title": f"[{self.account}] {title}",
                         "description": f"We claimed an **{reward}** from <https://lolesports.com/rewards>",
                         "image" : {"url": f"{thumbnail}"},
                         "thumbnail": {"url": f"{rewardImage}"},
@@ -89,8 +89,7 @@ class FarmThread(Thread):
                     }
 
                     params = {
-                        "username" : "LoL Esports",
-                        "avatar_url": "http://assets.lolesports.com/watch/lolesports-icon-ice.png",
+                        "username" : "CapsuleFarmerEvolved",
                         "embeds": [embed]
                     }
                     requests.post(self.config.connectorDrops, headers={"Content-type":"application/json"}, json=params)


### PR DESCRIPTION
Added Discord Webhook support using requests

To enable, set `connectorDropsUrl` in `config.yaml` to a Discord Webhook URL
![config.yaml](https://i.imgur.com/PUhXCa7.png)

# Preview:
![Discord Webhook Image](https://i.imgur.com/ANQZIPp.png)