### PR TITLE
feat: Added retrieving summoner name and region

### DIFF
--- a/src/FarmThread.py
+++ b/src/FarmThread.py
@@ -31,7 +31,7 @@ class FarmThread(Thread):
         Start watching every live match
         """
         try:
-            self.stats.updateStatus(self.account, "[green]LOGIN")
+            self.stats.updateStatus(self.account, "[yellow]LOGGING IN")
             if self.browser.login(self.config.getAccount(self.account)["username"], self.config.getAccount(self.account)["password"], self.locks["refreshLock"]):
                 self.stats.updateStatus(self.account, "[green]LIVE")
                 self.stats.resetLoginFailed(self.account)

--- a/src/FarmThread.py
+++ b/src/FarmThread.py
@@ -23,7 +23,7 @@ class FarmThread(Thread):
         self.config = config
         self.account = account
         self.stats = stats
-        self.browser = Browser(self.log, self.config, self.account)
+        self.browser = Browser(self.log, stats, self.config, self.account)
         self.locks = locks
 
     def run(self):

--- a/src/GuiThread.py
+++ b/src/GuiThread.py
@@ -34,7 +34,6 @@ class GuiThread(Thread):
         table.add_column("Drops")
 
         for acc in self.stats.accountData:
-            status = self.stats.accountData[acc]["status"]
             table.add_row(f"{self.stats.accountData[acc]['account']}",f"{self.stats.accountData[acc]['region']}", f"{self.stats.accountData[acc]['status']}", f"{self.stats.accountData[acc]['liveMatches']}", f"{self.stats.accountData[acc]['lastCheck']}", f"{self.stats.accountData[acc]['lastDrop']}", f"{self.stats.accountData[acc]['totalDrops']}")
         return table
 

--- a/src/GuiThread.py
+++ b/src/GuiThread.py
@@ -26,6 +26,7 @@ class GuiThread(Thread):
     def generateTable(self):
         table = Table()
         table.add_column("Account")
+        table.add_column("Region")
         table.add_column("Status")
         table.add_column("Live matches")
         table.add_column("Heartbeat")
@@ -34,8 +35,7 @@ class GuiThread(Thread):
 
         for acc in self.stats.accountData:
             status = self.stats.accountData[acc]["status"]
-            table.add_row(f"{acc}", f"{status}", f"{self.stats.accountData[acc]['liveMatches']}", f"{self.stats.accountData[acc]['lastCheck']}", f"{self.stats.accountData[acc]['lastDrop']}", f"{self.stats.accountData[acc]['totalDrops']}")
-            # table.add_row(f"{acc}", f"{status}", f"{self.stats.accountData[acc]['liveMatches']}", f"{self.stats.accountData[acc]['lastCheck']}")
+            table.add_row(f"{self.stats.accountData[acc]['account']}",f"{self.stats.accountData[acc]['region']}", f"{self.stats.accountData[acc]['status']}", f"{self.stats.accountData[acc]['liveMatches']}", f"{self.stats.accountData[acc]['lastCheck']}", f"{self.stats.accountData[acc]['lastDrop']}", f"{self.stats.accountData[acc]['totalDrops']}")
         return table
 
     def run(self):

--- a/src/Stats.py
+++ b/src/Stats.py
@@ -6,7 +6,7 @@ class Stats:
         self.accountData = {}
 
     def initNewAccount(self, accountName: str):
-        self.accountData[accountName] = {"lastCheck": "", "totalDrops": 0, "lastDrop": "N/A", "liveMatches": "", "status": "[yellow]WAIT", "failedLoginCounter": 0, "lastDropCheck": int(datetime.now().timestamp()*1e3)}
+        self.accountData[accountName] = {"account": "N/A", "region": "N/A", "lastCheck": "", "totalDrops": 0, "lastDrop": "N/A", "liveMatches": "", "status": "[yellow]WAIT", "failedLoginCounter": 0, "lastDropCheck": int(datetime.now().timestamp()*1e3)}
     
     def update(self, accountName: str, newDrops: int = 0, liveMatches: str = ""):
         self.accountData[accountName]["lastCheck"] = datetime.now().strftime("%H:%M:%S %d/%m")
@@ -14,10 +14,16 @@ class Stats:
         if newDrops > 0:
             self.accountData[accountName]["totalDrops"] += newDrops
             self.accountData[accountName]["lastDrop"] = datetime.now().strftime("%H:%M:%S %d/%m")
-    
+
+    def updateName(self, accountName: str, realName: str):
+        self.accountData[accountName]["account"] = realName
+
+    def updateRegion(self, accountName: str, region: str):
+        self.accountData[accountName]["region"] = region
+
     def updateStatus(self, accountName: str, msg: str):
         self.accountData[accountName]["status"] = msg
-    
+
     def updateLastDropCheck(self, accountName: str, lastDropCheck: int):
         self.accountData[accountName]["lastDropCheck"] = lastDropCheck
     


### PR DESCRIPTION
Example of retrieving summoner name and region:
![image](https://user-images.githubusercontent.com/45354930/217361118-f56b7471-ef64-48f5-9338-4c883ba2223e.png)
If it fails, it will go back to use config account names.

- Changed  `LOGIN` to `LOGGING IN`  colored `yellow`.

Has been tested on Windows & Ubuntu 22.04