### PR TITLE
feat: Automatically restart threads with increasing delay

### DIFF
--- a/src/Restarter.py
+++ b/src/Restarter.py
@@ -1,0 +1,39 @@
+from datetime import datetime, timedelta
+
+
+class Restarter:
+    def __init__(self, accountStats) -> None:
+        self.stats = accountStats
+        self.startTimes = {acc: datetime.now()
+                           for acc in accountStats.accountData}
+
+    def setRestartDelay(self, accountName: str):
+        """
+        Get the earliest time of the next thread restart based on the number of failed logins
+
+        :param accountName: string, name of the account 
+        """
+        failedLogins = self.stats.getFailedLogins(accountName)
+
+        # do not use match-case to maintain compatibility with Python 3.9
+        delay = 0
+        if failedLogins == 1:
+            delay = 10
+        elif failedLogins == 2:
+            delay = 30
+        elif failedLogins == 3:
+            delay = 150
+        elif failedLogins == 4:
+            delay = 300
+        elif failedLogins == 5:
+            delay = 600
+        elif failedLogins >= 6:
+            delay = 1800
+        self.startTimes[accountName] = datetime.now() + \
+            timedelta(seconds=delay)
+
+    def getNextStart(self, accountName: str) -> datetime:
+        return self.startTimes[accountName]
+
+    def canRestart(self, accountName: str) -> bool:
+        return self.getNextStart(accountName) < datetime.now()

--- a/src/main.py
+++ b/src/main.py
@@ -75,7 +75,7 @@ def main(log: logging.Logger, config: Config):
                 toDelete.append(account)
                 restarter.setRestartDelay(account)
                 stats.updateStatus(account, f"[red]ERROR - restart at {restarter.getNextStart(account).strftime('%H:%M:%S')}, failed logins: {stats.getFailedLogins(account)}")
-                log.warning(f"Thread {account} has finished.")
+                log.warning(f"Thread {account} has finished and will restart at {restarter.getNextStart(account).strftime('%H:%M:%S')}. Number of consecutively failed logins: {stats.getFailedLogins(account)}")
         for account in toDelete:
             del farmThreads[account]
 

--- a/src/main.py
+++ b/src/main.py
@@ -11,6 +11,7 @@ import argparse
 from rich import print
 from pathlib import Path
 from time import sleep
+from Restarter import Restarter
 
 from Stats import Stats
 from VersionManager import VersionManager
@@ -50,34 +51,21 @@ def main(log: logging.Logger, config: Config):
     stats = Stats(farmThreads)
     for account in config.accounts:
         stats.initNewAccount(account)
-
+    restarter = Restarter(stats)
     log.info(f"Starting a GUI thread.")
     gui = GuiThread(log, config, stats, locks)
     gui.daemon = True
     gui.start()
 
     while True:
-        toDelete = []
         for account in config.accounts:
-            if account not in farmThreads:
-                if stats.getFailedLogins(account) < 3:
-                    if stats.getFailedLogins(account) > 0:
-                        log.debug("Sleeping {account} before retrying login.")
-                        sleep(30)
-                    log.info(f"Starting a thread for {account}.")
-                    thread = FarmThread(log, config, account, stats, locks)
-                    thread.daemon = True
-                    thread.start()
-                    farmThreads[account] = thread
-                    log.info(f"Thread for {account} was created.")
-                else:
-                    stats.updateStatus(account, "[red]LOGIN FAILED")
-                    log.error(f"Maximum login retries reached for account {account}")
-                    toDelete.append(account)
-        if not farmThreads:
-            break
-        for account in toDelete:
-            del config.accounts[account]    
+            if account not in farmThreads and restarter.canRestart(account):
+                log.info(f"Starting a thread for {account}.")
+                thread = FarmThread(log, config, account, stats, locks)
+                thread.daemon = True
+                thread.start()
+                farmThreads[account] = thread
+                log.info(f"Thread for {account} was created.")    
 
         toDelete = []
         for account in farmThreads:
@@ -85,6 +73,8 @@ def main(log: logging.Logger, config: Config):
                 farmThreads[account].join(1)
             else:
                 toDelete.append(account)
+                restarter.setRestartDelay(account)
+                stats.updateStatus(account, f"[red]ERROR - restart at {restarter.getNextStart(account).strftime('%H:%M:%S')}, failed logins: {stats.getFailedLogins(account)}")
                 log.warning(f"Thread {account} has finished.")
         for account in toDelete:
             del farmThreads[account]


### PR DESCRIPTION
This PR gets rid of the three consecutively failed logins limit and instead implements increasing delay based on the number of failed logins. The delay is reset after a successful login.