### PR TITLE
feat: Remove dummy accounts from config

### DIFF
--- a/src/Config.py
+++ b/src/Config.py
@@ -24,16 +24,13 @@ class Config:
             with open(configPath, "r",  encoding='utf-8') as f:
                 config = yaml.safe_load(f)
                 accs = config.get("accounts")
-                onlyDefaultUsername = True
                 for account in accs:
-                    self.accounts[account] = {
-                        "username": accs[account]["username"],
-                        "password": accs[account]["password"],
-
-                    }
                     if "username" != accs[account]["username"]:
-                        onlyDefaultUsername = False
-                if onlyDefaultUsername:
+                        self.accounts[account] = {
+                            "username": accs[account]["username"],
+                            "password": accs[account]["password"]
+                        }                    
+                if not self.accounts:
                     raise InvalidCredentialsException                    
                 self.debug = config.get("debug", False)
                 self.connectorDrops = config.get("connectorDropsUrl", "")


### PR DESCRIPTION
Remove any account whose username is "username". They are leftovers from users not editing the config properly.

![image](https://user-images.githubusercontent.com/95635582/217520751-5be49860-a611-48c5-9b39-33760142c437.png)
