### PR TITLE
fix: Possible infinite loop in session refresh.

### DIFF
--- a/src/Browser.py
+++ b/src/Browser.py
@@ -118,7 +118,6 @@ class Browser:
         resAccessToken = self.client.get(
             "https://account.rewards.lolesports.com/v1/session/refresh", headers=headers)
         if resAccessToken.status_code == 200:
-            self.maintainSession()
             self.__dumpCookies()
         else:
             self.log.error("Failed to refresh session")


### PR DESCRIPTION
If session refresh fails, it can send the program to an infinite loop and cause rate limiting.