### PR TITLE
fix: Properly close all connections

### DIFF
--- a/src/Browser.py
+++ b/src/Browser.py
@@ -81,17 +81,15 @@ class Browser:
         if token and state:
             data = {"token": token, "state": state}
             self.client.post(
-                "https://login.riotgames.com/sso/login", data=data)
+                "https://login.riotgames.com/sso/login", data=data).close()
             self.client.post(
-                "https://login.lolesports.com/sso/login", data=data)
+                "https://login.lolesports.com/sso/login", data=data).close()
             self.client.post(
-                "https://login.playvalorant.com/sso/login", data=data)
-
-            res = self.client.post(
-                "https://login.leagueoflegends.com/sso/callback", data=data)
-
-            res = self.client.get(
-                "https://auth.riotgames.com/authorize?client_id=esports-rna-prod&redirect_uri=https://account.rewards.lolesports.com/v1/session/oauth-callback&response_type=code&scope=openid&prompt=none&state=https://lolesports.com/?memento=na.en_GB", allow_redirects=True)
+                "https://login.playvalorant.com/sso/login", data=data).close()
+            self.client.post(
+                "https://login.leagueoflegends.com/sso/callback", data=data).close()
+            self.client.get(
+                "https://auth.riotgames.com/authorize?client_id=esports-rna-prod&redirect_uri=https://account.rewards.lolesports.com/v1/session/oauth-callback&response_type=code&scope=openid&prompt=none&state=https://lolesports.com/?memento=na.en_GB", allow_redirects=True).close()
 
             # Get access and entitlement tokens for the first time
             headers = {"Origin": "https://lolesports.com",
@@ -102,9 +100,8 @@ class Browser:
                 "https://account.rewards.lolesports.com/v1/session/token", headers=headers)
             # Currently unused but the call might be important server-side
             resPasToken = self.client.get(
-                "https://account.rewards.lolesports.com/v1/session/clientconfig/rms", headers=headers)
+                "https://account.rewards.lolesports.com/v1/session/clientconfig/rms", headers=headers).close()
             if resAccessToken.status_code == 200:
-                #self.maintainSession()
                 self.__dumpCookies()
                 return True
         return False
@@ -117,6 +114,7 @@ class Browser:
                    "Referrer": "https://lolesports.com"}
         resAccessToken = self.client.get(
             "https://account.rewards.lolesports.com/v1/session/refresh", headers=headers)
+        resAccessToken.close()
         if resAccessToken.status_code == 200:
             self.__dumpCookies()
         else:
@@ -142,6 +140,7 @@ class Browser:
         if res.status_code != 200:
             raise StatusCodeAssertException(200, res.status_code, res.request.url)
         resJson = res.json()
+        res.close()
         self.liveMatches = {}
         try:
             events = resJson["data"]["schedule"].get("events", [])
@@ -168,10 +167,10 @@ class Browser:
         """
         dropsAvailable = {}
         for tid in self.liveMatches:
-            res = self.__sendWatch(self.liveMatches[tid])
+            resJson = self.__sendWatch(self.liveMatches[tid])
             self.log.debug(
-                f"{self.account} - {self.liveMatches[tid].league}: {res.json()}")
-            if res.json()["droppability"] == "on":   
+                f"{self.account} - {self.liveMatches[tid].league}: {resJson}")
+            if resJson["droppability"] == "on":   
                 dropsAvailable[self.liveMatches[tid].league] = True
             else:
                 dropsAvailable[self.liveMatches[tid].league] = False
@@ -184,6 +183,7 @@ class Browser:
                    "Authorization": "Cookie access_token"}
             res = self.client.get("https://account.service.lolesports.com/fandom-account/v1/earnedDrops?locale=en_GB&site=LOLESPORTS", headers=headers)
             resJson = res.json()
+            res.close()
             return [drop for drop in resJson if lastCheckTime <= drop["unlockedDateMillis"]]
         except (KeyError, TypeError):
             self.log.debug("Drop check failed")
@@ -216,9 +216,11 @@ class Browser:
                    "Referrer": "https://lolesports.com"}
         res = self.client.post(
             "https://rex.rewards.lolesports.com/v1/events/watch", headers=headers, json=data)
+        resJson = res.json()
+        res.close()
         if res.status_code != 201:
             raise StatusCodeAssertException(201, res.status_code, res.request.url)
-        return res
+        return resJson
 
     def __getLoginTokens(self, form: str) -> tuple[str, str]:
         """


### PR DESCRIPTION
Properly close all connections to prevent `Too many open files` error caused by requests leaving sockets open.

Example:
`urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='login.leagueoflegends.com', port=443): Max retries exceeded with url: /?redirect_uri=https://lolesports.com/&lang=en (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7fa040a126d0>: Failed to establish a new connection: [Errno 24] Too many open files'))`