### PR TITLE
Add more entries to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,4 +168,5 @@ cython_debug
 #  be found at httpsgithub.comgithubgitignoreblobmainGlobalJetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea
+.idea
+src/sessions


### PR DESCRIPTION
Current state of gitignore makes creating pull requests unnecessarily messy when using PyCharm IDE.
All `.idea` contents are related to local machine, so they should never be within version control.

Additionally, added src/sessions to prevent publishing private data by accident.