### PR TITLE
fix: Correctly catch RateLimitException

### DIFF
--- a/src/Browser.py
+++ b/src/Browser.py
@@ -74,6 +74,8 @@ class Browser:
             res = self.client.get(resJson["response"]["parameters"]["uri"])
         except KeyError:
             return False
+        except RateLimitException as ex:
+            self.log.error(f"You are being rate-limited. Retry after {ex}")
         finally:
             refreshLock.release()
         # Login to lolesports.com, riotgames.com, and playvalorant.com

--- a/src/Browser.py
+++ b/src/Browser.py
@@ -76,6 +76,7 @@ class Browser:
             return False
         except RateLimitException as ex:
             self.log.error(f"You are being rate-limited. Retry after {ex}")
+            return False
         finally:
             refreshLock.release()
         # Login to lolesports.com, riotgames.com, and playvalorant.com


### PR DESCRIPTION
The RateLimitException was correctly caught, resulting in incorrect wait times. Additionally, the exception is now properly logged.