### PR TITLE
feat: change log handler to RotatingFileHandler

### DIFF
--- a/src/Logger.py
+++ b/src/Logger.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime
 from logging.handlers import RotatingFileHandler
 
 FILE_SIZE = 1024 * 1024 * 100  # 100 MB
@@ -15,7 +14,7 @@ class Logger:
             level = logging.WARNING
 
         fileHandler = RotatingFileHandler(
-            f'./logs/capsulefarmer-{datetime.now().strftime("%Y-%m-%d")}.log',
+            "./logs/capsulefarmer.log",
             mode="a+",
             maxBytes=FILE_SIZE,
             backupCount=BACKUP_COUNT,

--- a/src/Logger.py
+++ b/src/Logger.py
@@ -1,6 +1,9 @@
 import logging
-import logging.config
 from datetime import datetime
+from logging.handlers import RotatingFileHandler
+
+FILE_SIZE = 1024 * 1024 * 100  # 100 MB
+BACKUP_COUNT = 5  # keep up to 5 files
 
 
 class Logger:
@@ -11,10 +14,18 @@ class Logger:
         else:
             level = logging.WARNING
 
-        logging.basicConfig(filename=f'./logs/capsulefarmer-{datetime.now().strftime("%Y-%m-%d")}.log',
-                            filemode="a+",
-                            format='%(asctime)s %(levelname)s: %(message)s',
-                            level=level)
+        fileHandler = RotatingFileHandler(
+            f'./logs/capsulefarmer-{datetime.now().strftime("%Y-%m-%d")}.log',
+            mode="a+",
+            maxBytes=FILE_SIZE,
+            backupCount=BACKUP_COUNT,
+        )
+
+        logging.basicConfig(
+            format="%(asctime)s %(levelname)s: %(message)s",
+            level=level,
+            handlers=[fileHandler],
+        )
         log = logging.getLogger("League of Poro")
         log.info("-------------------------------------------------")
         log.info("---------------- Program started ----------------")


### PR DESCRIPTION
Change log handler to rotating so that logs don't use more than 100 MB before being closed and backed up. Currently create up to 5 backups. This can be changed by modifying `BACKUP_COUNT` and `FILE_SIZE` to ensure that log files don't take too much space.