### PR TITLE
fix: replace undefined log with print

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -96,4 +96,4 @@ if __name__ == '__main__':
         print('Exiting. Thank you for farming with us!')
         sys.exit()
     except CapsuleFarmerEvolvedException as e:
-        log.error(f'An error has occurred: {e}')
+        print(f'[red]An error has occurred: {e}')

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,3 @@
-
 from DataProviderThread import DataProviderThread
 from Exceptions.CapsuleFarmerEvolvedException import CapsuleFarmerEvolvedException
 from FarmThread import FarmThread
@@ -89,6 +88,7 @@ def main(log: logging.Logger, config: Config):
 
 
 if __name__ == '__main__':
+    log = None
     try:
         log, config = init()
         main(log, config)
@@ -96,4 +96,7 @@ if __name__ == '__main__':
         print('Exiting. Thank you for farming with us!')
         sys.exit()
     except CapsuleFarmerEvolvedException as e:
-        print(f'[red]An error has occurred: {e}')
+        if isinstance(log, logging.Logger):
+            log.error(f"An error has occurred: {e}")
+        else:
+            print(f'[red]An error has occurred: {e}')


### PR DESCRIPTION
replace `log.error` in `try: except` with `print` since an exception will always mean it's undefined