### PR TITLE
fix: Change LOGIN status color from green to yellow

### DIFF
--- a/src/FarmThread.py
+++ b/src/FarmThread.py
@@ -34,7 +34,7 @@ class FarmThread(Thread):
         Start watching every live match
         """
         try:
-            self.stats.updateStatus(self.account, "[green]LOGIN")
+            self.stats.updateStatus(self.account, "[yellow]LOGIN")
             if self.browser.login(self.config.getAccount(self.account)["username"], self.config.getAccount(self.account)["password"], self.locks["refreshLock"]):
                 self.stats.updateStatus(self.account, "[green]LIVE")
                 self.stats.resetLoginFailed(self.account)


### PR DESCRIPTION
<!-- !!!! Do not delete this pull request template! !!!! -->
<!-- Pull requests that do not follow this template are likely to be ignored and closed. -->

## Summary of Changes
Change LOGIN status color from green to yellow

## Additional context
Logically LOGIN status can fail and turn to [red]LOGIN FAILED after a failed login, so while a login is being attempted it should be yellow color as the login is not yet finished.

<!-- You may optionally provide your discord username, so that we may contact you directly about the PR if need be. -->
Math7#3698

## Testing instructions
When starting the program, LOGIN status will be yellow.

<!-- DO NOT DELETE THIS -->
## How to download the PR for testing

1. Clone this PR
2. Run `gh pr checkout 124` (Requires [GitHub CLI](https://cli.github.com/)) 
3. Follow the [Advanced Installation Guides from the Wiki](https://github.com/LeagueOfPoro/CapsuleFarmerEvolved/wiki)
