### PR TITLE
docs: Fix Discord link, add info to readme

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Questions or Discussions
-    url: https://discord.gg/ebm5MJNvHU/
+    url: https://discord.gg/ebm5MJNvHU
     about: "Check out our Discord server for questions or discussions! Locate the #capsule-farmer channel!"

--- a/README.md
+++ b/README.md
@@ -36,10 +36,12 @@ This is a successor to the old [EsportsCapsuleFarmer](https://github.com/LeagueO
 - Very lightweight - no external browser needed
 - Simple GUI
 - 2FA (experimental) - programs prompts for the code on startup
+- Docker supported
 - ARM supported (Raspberry Pi)
+- [Discord Webhook support](https://github.com/LeagueOfPoro/CapsuleFarmerEvolved/wiki/Configuration#configuration-options)
 
 ## Community
-If you have any type of issue, need help, or just want to hangout. Come to [League of Poro's Discord server](https://discord.gg/c2Qs9Y83hh).
+If you have any type of issue, need help, or just want to hangout. Come to [League of Poro's Discord server](https://discord.gg/ebm5MJNvHU).
 
 ## Support my work
 [Subscribe to my channel on YouTube](https://www.youtube.com/channel/UCwgpdTScSd788qILhLnyyyw?sub_confirmation=1) or even


### PR DESCRIPTION


<!-- !!!! Do not delete this pull request template! !!!! -->
<!-- Pull requests that do not follow this template are likely to be ignored and closed. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #135 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Removed extra slash at the end of discord link in Issue template config.yaml

Added to readme.md -- docker support, discord webhook feature. changed discord link to match with what is displayed in farmer and issue template. 


## Additional context
<!-- Add any other context about the pull request here. -->
<!-- You may optionally provide your discord username, so that we may contact you directly about the PR if need be. -->
Discord username (if different from GitHub): RustyWalls#9782

## Testing instructions
<!-- What should we look for when testing this PR. -->
Test issue template discord link button.

Double check discord link, advise if discord webhook hyperlinked good in features.


<!-- DO NOT DELETE THIS -->
## How to download the PR for testing

1. Clone this PR
2. Run `gh pr checkout 137` (Requires [GitHub CLI](https://cli.github.com/)) 
3. Follow the [Advanced Installation Guides from the Wiki](https://github.com/LeagueOfPoro/CapsuleFarmerEvolved/wiki)
