### PR TITLE
fix: Show correct time until next match

### DIFF
--- a/src/DataProviderThread.py
+++ b/src/DataProviderThread.py
@@ -88,11 +88,7 @@ class DataProviderThread(Thread):
             for event in events:
                 if event["state"] == "unstarted":
                     if self._isStartTimeLater(event["startTime"]):  # startTime is later
-                        timeUntil = self.startTime - self.currentTime
-                        total_seconds = int(timeUntil.total_seconds())
-                        days, remainder = divmod(total_seconds, 86400)
-                        hours, remainder = divmod(remainder, 3600)
-                        minutes, seconds = divmod(remainder, 60)
+                        days, hours, minutes = self._calculateTime()
                         self.sharedData.setTimeUntilNextMatch(
                             f"None - next in {days}d {hours}h" if days else f'None - next in {hours}h {minutes}m')
                         break
@@ -102,11 +98,7 @@ class DataProviderThread(Thread):
                         for nextEvent in events:  # Looping again to find next match that weren't supposed to have started already
                             if nextEvent["state"] == "unstarted":
                                 if self._isStartTimeLater(nextEvent["startTime"]):
-                                    timeUntil = self.startTime - self.currentTime
-                                    total_seconds = int(timeUntil.total_seconds())
-                                    days, remainder = divmod(total_seconds, 86400)
-                                    hours, remainder = divmod(remainder, 3600)
-                                    minutes, seconds = divmod(remainder, 60)
+                                    days, hours, minutes = self._calculateTime()
                                     self.sharedData.addTimeUntilNextMatch(
                                         f"Next in {days}d {hours}h" if days else f'Next in {hours}h {minutes}m')
                                     break
@@ -129,3 +121,16 @@ class DataProviderThread(Thread):
         currentTimeString = datetime.now(timezone.utc).strftime(datetimeFormat)
         self.currentTime = datetime.strptime(currentTimeString, datetimeFormat)
         return self.currentTime < self.startTime
+
+    def _calculateTime(self) -> tuple:
+        """
+        Calculates time until next match
+
+        :return: tuple, days, hours, minutes
+        """
+        timeUntil = self.startTime - self.currentTime
+        total_seconds = int(timeUntil.total_seconds())
+        days, remainder = divmod(total_seconds, 86400)
+        hours, remainder = divmod(remainder, 3600)
+        minutes, seconds = divmod(remainder, 60)
+        return days, hours, minutes

--- a/src/DataProviderThread.py
+++ b/src/DataProviderThread.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timezone, timedelta
 from threading import Thread
 from time import sleep
-
 import cloudscraper
 
 from AssertCondition import AssertCondition

--- a/src/DataProviderThread.py
+++ b/src/DataProviderThread.py
@@ -1,8 +1,7 @@
-from datetime import datetime
 from threading import Thread
 from time import sleep
 import cloudscraper
-
+from datetime import datetime, timezone
 from AssertCondition import AssertCondition
 from Exceptions.StatusCodeAssertException import StatusCodeAssertException
 from Match import Match
@@ -90,9 +89,9 @@ class DataProviderThread(Thread):
                         startTime = datetime.strptime(event["startTime"], '%Y-%m-%dT%H:%M:%SZ') #Some matches aparrently don't have a starttime
                 except:
                     continue
-                if datetime.now() < startTime:
+                if datetime.now(timezone.utc) < startTime:
                     timeUntil = startTime - datetime.now()
-                    total_seconds = int(timeUntil.total_seconds() + 3600)
+                    total_seconds = int(timeUntil.total_seconds())
                     days, remainder = divmod(total_seconds, 86400)
                     hours, remainder = divmod(remainder, 3600)
                     minutes, seconds = divmod(remainder, 60)

--- a/src/SharedData.py
+++ b/src/SharedData.py
@@ -2,7 +2,7 @@ class SharedData:
     def __init__(self) -> None:
         self.liveMatches = {}
         self.timeUntilNextMatch = "None"
-    
+
     def setLiveMatches(self, liveMatches):
         self.liveMatches = liveMatches
 
@@ -11,9 +11,6 @@ class SharedData:
 
     def setTimeUntilNextMatch(self, timeUntilNextMatch):
         self.timeUntilNextMatch = timeUntilNextMatch
-
-    def addTimeUntilNextMatch(self, timeUntilNextMatch):
-        self.timeUntilNextMatch += "\n" + timeUntilNextMatch
 
     def getTimeUntilNextMatch(self):
         return self.timeUntilNextMatch

--- a/src/SharedData.py
+++ b/src/SharedData.py
@@ -12,5 +12,8 @@ class SharedData:
     def setTimeUntilNextMatch(self, timeUntilNextMatch):
         self.timeUntilNextMatch = timeUntilNextMatch
 
+    def addTimeUntilNextMatch(self, timeUntilNextMatch):
+        self.timeUntilNextMatch += "\n" + timeUntilNextMatch
+
     def getTimeUntilNextMatch(self):
         return self.timeUntilNextMatch


### PR DESCRIPTION
<!-- !!!! Do not delete this pull request template! !!!! -->
<!-- Pull requests that do not follow this template are likely to be ignored and closed. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #124 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Properly displays time until next match in the Live Matches column.

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the PR if need be. -->
Discord username (if different from GitHub): Frozty

## Testing instructions
<!-- What should we look for when testing this PR. -->
Sometimes it won't be able to set a time because the json response is not up to date. Usually happens right as a match goes live and the event will show 'state': 'unstarted' when its actually live(should be 'state': 'inProgress'). The issue resolves itself as the data is updated. It gave me a headache during testing, so just keep it in mind.


<!-- DO NOT DELETE THIS -->
## How to download the PR for testing

### Using [GitHub CLI](https://cli.github.com/)
1. Clone this PR
2. Run `gh pr checkout 124` (Requires [GitHub CLI](https://cli.github.com/)) 
3. Follow the [Advanced Installation Guides from the Wiki](https://github.com/LeagueOfPoro/CapsuleFarmerEvolved/wiki)

### Using regular GIT
1. Fetch the PR `git fetch origin pull/<PR_NUMBER>/head:<LOCAL_BRANCH_NAME>` (e.g. `git fetch origin pull/110/head:notif`)
2. Checkout the branch `git checkout <LOCAL_BRANCH_NAME>` (e.g. `git checkout notif`)
3. Follow the [Advanced Installation Guides from the Wiki](https://github.com/LeagueOfPoro/CapsuleFarmerEvolved/wiki)
