### PR TITLE
feat: Show program version in log file

### DIFF
--- a/src/Logger.py
+++ b/src/Logger.py
@@ -7,7 +7,7 @@ BACKUP_COUNT = 5  # keep up to 5 files
 
 class Logger:
     @staticmethod
-    def createLogger(debug: bool):
+    def createLogger(debug: bool, version: float):
         if debug:
             level = logging.DEBUG
         else:
@@ -27,6 +27,6 @@ class Logger:
         )
         log = logging.getLogger("League of Poro")
         log.info("-------------------------------------------------")
-        log.info("---------------- Program started ----------------")
+        log.info(f"----------- Program started  v{version} ---------------")
         log.info("-------------------------------------------------")
         return log

--- a/src/main.py
+++ b/src/main.py
@@ -37,7 +37,7 @@ def init() -> tuple[logging.Logger, Config]:
     Path("./logs/").mkdir(parents=True, exist_ok=True)
     Path("./sessions/").mkdir(parents=True, exist_ok=True)
     config = Config(args.configPath)
-    log = Logger.createLogger(config.debug)
+    log = Logger.createLogger(config.debug, CURRENT_VERSION)
     if not VersionManager.isLatestVersion(CURRENT_VERSION):
         log.warning("!!! NEW VERSION AVAILABLE !!! Download it from: https://github.com/LeagueOfPoro/CapsuleFarmerEvolved/releases/latest")
         print("[bold red]!!! NEW VERSION AVAILABLE !!!\nDownload it from: https://github.com/LeagueOfPoro/CapsuleFarmerEvolved/releases/latest\n")


### PR DESCRIPTION
Fixes #130

## Summary of Changes
Updates the log file to include the program version number, making it easier to debug logs.

![image](https://user-images.githubusercontent.com/60130987/219143429-402ad8e0-49cc-4947-86c2-a04f9e800ad3.png)

## Additional context
Discord username (if different from GitHub): Spirax#3775

## Testing instructions
Verify that the log message shows the latest version number on launch.

<!-- DO NOT DELETE THIS -->
## How to download the PR for testing

### Using [GitHub CLI](https://cli.github.com/)
1. Clone this PR
2. Run `gh pr checkout 124` (Requires [GitHub CLI](https://cli.github.com/)) 
3. Follow the [Advanced Installation Guides from the Wiki](https://github.com/LeagueOfPoro/CapsuleFarmerEvolved/wiki)

### Using regular GIT
1. Fetch the PR `git fetch origin pull/<PR_NUMBER>/head:<LOCAL_BRANCH_NAME>` (e.g. `git fetch origin pull/110/head:notif`)
2. Checkout the branch `git checkout <LOCAL_BRANCH_NAME>` (e.g. `git checkout notif`)
3. Follow the [Advanced Installation Guides from the Wiki](https://github.com/LeagueOfPoro/CapsuleFarmerEvolved/wiki)
