### PR TITLE
fix: Fixed display of UnicodeEncodeError

### DIFF
--- a/src/DataProviderThread.py
+++ b/src/DataProviderThread.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from threading import Thread
 from time import sleep
 import cloudscraper
+from unidecode import unidecode
 
 from AssertCondition import AssertCondition
 from Exceptions.StatusCodeAssertException import StatusCodeAssertException
@@ -55,7 +56,7 @@ class DataProviderThread(Thread):
             for event in events:
                 tournamentId = event["tournament"]["id"]
                 if tournamentId not in liveMatches:
-                    league = event["league"]["name"]
+                    league = unidecode(event["league"]["name"])
                     if len(event["streams"]) > 0:
                         streamChannel = event["streams"][0]["parameter"]
                         streamSource = event["streams"][0]["provider"]


### PR DESCRIPTION
### **Fixed the issue of displaying characters in match names.**

`Arguments: ()
--- Logging error ---
Traceback (most recent call last):
  File "Browser.py", line 147, in sendWatchToLive
  File "Browser.py", line 194, in __sendWatch
  File "AssertCondition.py", line 11, in statusCodeMatches
Exceptions.StatusCodeAssertException.StatusCodeAssertException: Received unexpected status code. Wanted 201 but got 403
in https://rex.rewards.lolesports.com/v1/events/watch

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "logging\__init__.py", line 1103, in emit
  File "encodings\cp1251.py", line 19, in encode
UnicodeEncodeError: 'charmap' codec can't encode character '\xe7' in position 79: character maps to <undefined>
Call stack:
  File "threading.py", line 973, in _bootstrap
  File "threading.py", line 1016, in _bootstrap_inner
  File "FarmThread.py", line 43, in run
  File "Browser.py", line 149, in sendWatchToLive
  File "logging\__init__.py", line 1506, in error
  File "logging\__init__.py", line 1624, in _log
  File "logging\__init__.py", line 1634, in handle
  File "logging\__init__.py", line 1696, in callHandlers
  File "logging\__init__.py", line 968, in handle
  File "logging\handlers.py", line 75, in emit
  File "logging\__init__.py", line 1218, in emit
  File "logging\__init__.py", line 1108, in emit
Message: 'Failed to send watch heartbeat for La Ligue Française'`
