### PR TITLE
fix: "api crashing"

### DIFF
--- a/src/Browser.py
+++ b/src/Browser.py
@@ -41,8 +41,6 @@ class Browser:
         self.currentlyWatching = {}
         self.account = account
         self.sharedData = sharedData
-        self.header = "Referrer"
-
 
     def login(self, username: str, password: str, refreshLock) -> bool:
         """
@@ -119,8 +117,6 @@ class Browser:
         Refresh access and entitlement tokens
         """
         try:
-            headers = {"Origin": "https://lolesports.com",
-                    "Referrer": "https://lolesports.com"}
             resAccessToken = self.client.get(
                 "https://account.rewards.lolesports.com/v1/session/refresh", headers=headers)
             AssertCondition.statusCodeMatches(200, resAccessToken)
@@ -155,9 +151,7 @@ class Browser:
     
     def checkNewDrops(self, lastCheckTime):
         try:
-            headers = {"Origin": "https://lolesports.com",
-                   "Referrer": "https://lolesports.com",
-                   "Authorization": "Cookie access_token"}
+            headers = {"Authorization": "Cookie access_token"}
             res = self.client.get("https://account.service.lolesports.com/fandom-account/v1/earnedDrops?locale=en_GB&site=LOLESPORTS", headers=headers)
             resJson = res.json()
             res.close()
@@ -178,27 +172,19 @@ class Browser:
         return False
 
     def __sendWatch(self, match: Match):
-        
         """
         Sends watch event for a match
 
         :param match: Match object
         :return: object, response of the request
         """
-        def sendRequest(match):
-            data = {"stream_id": match.streamChannel,
+        data = {"stream_id": match.streamChannel,
                 "source": match.streamSource,
                 "stream_position_time": datetime.utcnow().isoformat(sep='T', timespec='milliseconds')+'Z',
                 "geolocation": {"code": "CZ", "area": "EU"},
                 "tournament_id": match.tournamentId}
-            return self.client.post("https://rex.rewards.lolesports.com/v1/events/watch", json=data)
-        res = sendRequest(match)
-        if res.status_code == 403 and self.header == "Referrer":
-            self.header = "Referer"
-            res = sendRequest(match)
-        else:
-            self.header = "Referrer"
-            res = sendRequest(match)
+        res = self.client.post(
+            "https://rex.rewards.lolesports.com/v1/events/watch", headers=headers, json=data)
         AssertCondition.statusCodeMatches(201, res)
         res.close()
 

--- a/src/Browser.py
+++ b/src/Browser.py
@@ -97,10 +97,6 @@ class Browser:
             self.client.get(
                 "https://auth.riotgames.com/authorize?client_id=esports-rna-prod&redirect_uri=https://account.rewards.lolesports.com/v1/session/oauth-callback&response_type=code&scope=openid&prompt=none&state=https://lolesports.com/?memento=na.en_GB", allow_redirects=True).close()
 
-            # Get access and entitlement tokens for the first time
-            headers = {"Origin": "https://lolesports.com",
-                        "Referrer": "https://lolesports.com"}
-
             # This requests sometimes returns 404
             resAccessToken = self.client.get(
                 "https://account.rewards.lolesports.com/v1/session/token", headers=headers)

--- a/src/Browser.py
+++ b/src/Browser.py
@@ -97,6 +97,10 @@ class Browser:
             self.client.get(
                 "https://auth.riotgames.com/authorize?client_id=esports-rna-prod&redirect_uri=https://account.rewards.lolesports.com/v1/session/oauth-callback&response_type=code&scope=openid&prompt=none&state=https://lolesports.com/?memento=na.en_GB", allow_redirects=True).close()
 
+            # Get access and entitlement tokens for the first time
+            headers = {"Origin": "https://lolesports.com"}
+
+
             # This requests sometimes returns 404
             resAccessToken = self.client.get(
                 "https://account.rewards.lolesports.com/v1/session/token", headers=headers)
@@ -113,6 +117,8 @@ class Browser:
         Refresh access and entitlement tokens
         """
         try:
+            headers = {"Origin": "https://lolesports.com"}
+
             resAccessToken = self.client.get(
                 "https://account.rewards.lolesports.com/v1/session/refresh", headers=headers)
             AssertCondition.statusCodeMatches(200, resAccessToken)
@@ -147,7 +153,9 @@ class Browser:
     
     def checkNewDrops(self, lastCheckTime):
         try:
-            headers = {"Authorization": "Cookie access_token"}
+            headers = {"Origin": "https://lolesports.com",
+
+                   "Authorization": "Cookie access_token"}
             res = self.client.get("https://account.service.lolesports.com/fandom-account/v1/earnedDrops?locale=en_GB&site=LOLESPORTS", headers=headers)
             resJson = res.json()
             res.close()
@@ -179,6 +187,8 @@ class Browser:
                 "stream_position_time": datetime.utcnow().isoformat(sep='T', timespec='milliseconds')+'Z',
                 "geolocation": {"code": "CZ", "area": "EU"},
                 "tournament_id": match.tournamentId}
+        headers = {"Origin": "https://lolesports.com"}
+
         res = self.client.post(
             "https://rex.rewards.lolesports.com/v1/events/watch", headers=headers, json=data)
         AssertCondition.statusCodeMatches(201, res)

--- a/src/DataProviderThread.py
+++ b/src/DataProviderThread.py
@@ -42,8 +42,7 @@ class DataProviderThread(Thread):
         """
         Retrieve data about currently live matches and store them.
         """
-        headers = {"Origin": "https://lolesports.com", "Referrer": "https://lolesports.com",
-                   "x-api-key": "0TvQnueqKa5mxJntVWt0w4LpLfEkrV1Ta8rQBb9Z"}
+        headers = {"x-api-key": "0TvQnueqKa5mxJntVWt0w4LpLfEkrV1Ta8rQBb9Z"}
         res = self.client.get(
             "https://esports-api.lolesports.com/persisted/gw/getLive?hl=en-GB", headers=headers)
         AssertCondition.statusCodeMatches(200, res)

--- a/src/DataProviderThread.py
+++ b/src/DataProviderThread.py
@@ -42,7 +42,8 @@ class DataProviderThread(Thread):
         """
         Retrieve data about currently live matches and store them.
         """
-        headers = {"x-api-key": "0TvQnueqKa5mxJntVWt0w4LpLfEkrV1Ta8rQBb9Z"}
+        headers = {
+                   "x-api-key": "0TvQnueqKa5mxJntVWt0w4LpLfEkrV1Ta8rQBb9Z"}
         res = self.client.get(
             "https://esports-api.lolesports.com/persisted/gw/getLive?hl=en-GB", headers=headers)
         AssertCondition.statusCodeMatches(200, res)
@@ -74,7 +75,8 @@ class DataProviderThread(Thread):
         """
         Retrieve data about currently live matches and store them.
         """
-        headers = {"x-api-key": "0TvQnueqKa5mxJntVWt0w4LpLfEkrV1Ta8rQBb9Z"}
+        headers = {
+                   "x-api-key": "0TvQnueqKa5mxJntVWt0w4LpLfEkrV1Ta8rQBb9Z"}
         try:
             res = self.client.get(
                 "https://esports-api.lolesports.com/persisted/gw/getSchedule?hl=en-GB", headers=headers)

--- a/src/DataProviderThread.py
+++ b/src/DataProviderThread.py
@@ -74,8 +74,7 @@ class DataProviderThread(Thread):
         """
         Retrieve data about currently live matches and store them.
         """
-        headers = {"Origin": "https://lolesports.com", "Referrer": "https://lolesports.com",
-                   "x-api-key": "0TvQnueqKa5mxJntVWt0w4LpLfEkrV1Ta8rQBb9Z"}
+        headers = {"x-api-key": "0TvQnueqKa5mxJntVWt0w4LpLfEkrV1Ta8rQBb9Z"}
         try:
             res = self.client.get(
                 "https://esports-api.lolesports.com/persisted/gw/getSchedule?hl=en-GB", headers=headers)

--- a/src/DataProviderThread.py
+++ b/src/DataProviderThread.py
@@ -42,7 +42,7 @@ class DataProviderThread(Thread):
         """
         Retrieve data about currently live matches and store them.
         """
-        headers = {
+        headers = {"Origin": "https://lolesports.com",
                    "x-api-key": "0TvQnueqKa5mxJntVWt0w4LpLfEkrV1Ta8rQBb9Z"}
         res = self.client.get(
             "https://esports-api.lolesports.com/persisted/gw/getLive?hl=en-GB", headers=headers)
@@ -75,7 +75,7 @@ class DataProviderThread(Thread):
         """
         Retrieve data about currently live matches and store them.
         """
-        headers = {
+        headers = {"Origin": "https://lolesports.com",
                    "x-api-key": "0TvQnueqKa5mxJntVWt0w4LpLfEkrV1Ta8rQBb9Z"}
         try:
             res = self.client.get(


### PR DESCRIPTION
# The Fix

Simply removed the headers that were causing the issue.

```py
"Origin": "https://lolesports.com", "Referrer": "https://lolesports.com"
```

Changes are on lines 45 and 78 in `DataProviderThread.py` along with 100, 120, 156, and 190 in `Browser.py`

This, as far as I can tell, completely fixes the issue with Riot's servers being "overloaded" 🤦‍♂️ (nobody wanted to believe me), while also being the simplest possible fix. In the event that this solution is not adequate, I have devised another that does not remove the headers from the request and instead changes the headers accordingly to the current state of Riot's API, assuming these lines had any use of course.

# Why I Think It Was Happening 

In my eyes, and this is complete speculation, Riot is either manually changing the required headers for the request to the drop API in an attempt to mitigate traffic, or they have their APIs configured to automatically change to a different server. However, it appears the setup for the other server uses `Referer` instead of `Referrer` as the header, causing the farmer to break when Riot's servers change. 

Credit to `RustyWalls#9782`, `Charlie#1001`, and `dimitrisz123#1466` for helping me test the changes, and giving feedback & ideas.

(P.S. Sorry for the DIFF issue, as you can see I tried to fix it twice but was unable, thanks GitHub 👍)