### PR TITLE
fix: Remove failed status

### DIFF
--- a/src/FarmThread.py
+++ b/src/FarmThread.py
@@ -46,15 +46,11 @@ class FarmThread(Thread):
                 self.stats.setTotalDrops(self.account, totalDrops)
                 while True:
                     self.browser.maintainSession()
-                    watchFailed = self.browser.sendWatchToLive()
                     newDrops = []
                     if self.sharedData.getLiveMatches():
                         liveMatchesStatus = []
                         for m in self.sharedData.getLiveMatches().values():
-                            if m.league in watchFailed:
-                                self.stats.updateStatus(self.account, "[red]RIOT SERVERS OVERLOADED - PLEASE WAIT")
-                            else:
-                                self.stats.updateStatus(self.account, "[green]LIVE")
+                            self.stats.updateStatus(self.account, "[green]LIVE")
                             liveMatchesStatus.append(m.league)
                         self.log.debug(f"Live matches: {', '.join(liveMatchesStatus)}")
                         liveMatchesMsg = f"{', '.join(liveMatchesStatus)}"


### PR DESCRIPTION
# Issue
Some users were experiencing an issue with the status being displayed as "RIOT SERVERS OVERLOADED - PLEASE WAIT" despite the farmer functioning correctly. 

# Solution
Removed the failed status, since it should no longer be possible for such an event to occur since patch 1.33 #156

Logs for such an event still exist, along with the red highlighting of leagues that the farmer was not able to get a heartbeat from, meaning if it was to somehow happen, it would still be diagnosable.